### PR TITLE
HU03 Se agrega el uso de corutinas para no bloquear el hilo principal

### DIFF
--- a/app/src/main/java/com/miso/vinilo/data/adapter/NetworkServiceAdapterMusician.kt
+++ b/app/src/main/java/com/miso/vinilo/data/adapter/NetworkServiceAdapterMusician.kt
@@ -6,6 +6,9 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Sealed class that represents the result of a network operation.
@@ -17,18 +20,25 @@ sealed class NetworkResult<out T> {
 
 /**
  * Network service adapter that uses a network API to retrieve musician data.
- * Other classes should call this implementation directly.
- * @property api The [com.miso.vinilo.data.adapter.retrofit.MusicianApi] instance used to perform network requests.
+ * The dispatcher used for IO is injected so tests can pass a TestDispatcher.
+ * @property api The [MusicianApi] instance used to perform network requests.
+ * @property ioDispatcher Dispatcher used for IO operations (defaults to [Dispatchers.IO]).
  */
-class NetworkServiceAdapterMusicians(private val api: MusicianApi) {
+class NetworkServiceAdapterMusicians(
+    private val api: MusicianApi,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
 
     /**
      * Fetches a list of musicians from the network API.
+     * Executes the call on the injected IO dispatcher to avoid blocking the UI thread.
      * @return A [NetworkResult] containing a list of [MusicianDto] on success or an [Error].
      */
     suspend fun getMusicians(): NetworkResult<List<MusicianDto>> {
         return try {
-            val dtos: List<MusicianDto> = api.getMusicians()
+            val dtos: List<MusicianDto> = withContext(ioDispatcher) {
+                api.getMusicians()
+            }
             NetworkResult.Success(dtos)
         } catch (e: Exception) {
             NetworkResult.Error("Unknown network error", e)

--- a/app/src/test/java/com/miso/vinilo/data/adapter/NetworkServiceAdapterMusiciansUnitTest.kt
+++ b/app/src/test/java/com/miso/vinilo/data/adapter/NetworkServiceAdapterMusiciansUnitTest.kt
@@ -3,24 +3,29 @@ package com.miso.vinilo.data.adapter
 import com.miso.vinilo.data.adapter.retrofit.MusicianApi
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class NetworkServiceAdapterMusiciansUnitTest {
 
     private val api = mockk<MusicianApi>()
-    private lateinit var adapter: NetworkServiceAdapterMusicians
 
     @Before
     fun setUp() {
-        adapter = NetworkServiceAdapterMusicians(api)
+        // no-op: adapter will be created inside each runTest with a TestDispatcher
     }
 
     @Test
     fun `getMusicians returns error when api throws IOException`() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val adapter = NetworkServiceAdapterMusicians(api, testDispatcher)
+
         coEvery { api.getMusicians() } throws IOException("network failure")
 
         val result = adapter.getMusicians()


### PR DESCRIPTION
En este PR:

1. Se agrega el uso de corutinas para la historia de listar artistas

______________

Evidencia:

1. Logs de logcat que fueron agregados temporalmente para que se evidenciara que se ejecutaban en diferentes hilos las instrucciones:
<img width="4747" height="398" alt="image" src="https://github.com/user-attachments/assets/072861b0-ca01-4371-a4c1-d0c08a749db3" />

2. Test corriendo:
<img width="1911" height="624" alt="image" src="https://github.com/user-attachments/assets/bf9b5773-6716-4096-89a3-fc9f66308722" />

3. App corriendo en API 36
<img width="1013" height="1349" alt="image" src="https://github.com/user-attachments/assets/ed30547b-8c76-420e-89cc-d869e24389ba" />

4. App corriendo en API 21
<img width="1111" height="1361" alt="image" src="https://github.com/user-attachments/assets/1cc97126-4d40-4b02-a368-77b5a5ee20be" />

