### PR TITLE
HU01: se agrega corutina para detalle del album, se corrigen codesmel…

### DIFF
--- a/app/src/main/java/com/miso/vinilo/MainActivity.kt
+++ b/app/src/main/java/com/miso/vinilo/MainActivity.kt
@@ -41,7 +41,6 @@ import com.miso.vinilo.ui.views.collectors.CollectorsScreen
 import com.miso.vinilo.ui.viewmodels.MusicianViewModel
 import com.miso.vinilo.ui.viewmodels.AlbumViewModel
 import com.miso.vinilo.ui.viewmodels.CollectorViewModel
-import com.miso.vinilo.data.dto.CollectorDto
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
buenos dias compañeros. 
En este PR subo lo siguiente: 
1. implementacion de corutina para el detalle del album. agrege logs temporales para demostrar la ejecucion de esta:
<img width="1627" height="144" alt="image" src="https://github.com/user-attachments/assets/9d9456f5-f33a-4e04-87b3-4f9a37c4b5ff" />

2. solucion de 3 codeSmells criticos a como se encuentra la rama Develop segun el reporte de sonnarqube, antes habian 11 codesmells ahora hay 9:
- imagen de los 3 codesmells 
<img width="1059" height="324" alt="image" src="https://github.com/user-attachments/assets/9dcd0d37-afef-4a8d-bca1-5c0a915e98d6" />


antes 
<img width="827" height="318" alt="image" src="https://github.com/user-attachments/assets/40474368-d4a0-4ae8-94dc-024bfa69a8db" />

despues
<img width="878" height="302" alt="image" src="https://github.com/user-attachments/assets/bbb839f3-ae16-431c-ae7e-2afed41ae787" />


la idea de este PR es cerrar la parte de la corrutina y continuar con los codesmells en otra rama. 
Gracias!